### PR TITLE
Fix crash in FileWatch.hpp on Windows because TCHAR wasn't WCHAR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ if (NOT CMAKE_BUILD_TYPE MATCHES "Release" AND NOT ANDROID AND NOT ${CMAKE_SYSTE
 endif()
 
 if(WIN32)
-	target_compile_definitions(pac PRIVATE _USE_MATH_DEFINES)
+	target_compile_definitions(pac PRIVATE _USE_MATH_DEFINES UNICODE)
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Release")


### PR DESCRIPTION
GetFullPathNameW was called with the wrong size, because `sizeof(TCHAR)` was 1 and not 2.