### PR TITLE
Checking precondition for dialog entry node

### DIFF
--- a/src/dialog/dialog_manager.cpp
+++ b/src/dialog/dialog_manager.cpp
@@ -36,7 +36,8 @@ void DialogManager::play(std::string characterName, jngl::Vec2, sol::function ca
     if (currentDialog)
     {
         currentNode = currentDialog->getEntryNode();
-        continueCurrent();
+        if(currentNode->checkPrecondition(currentDialog))
+            continueCurrent();
         dialog_callback = callback;
     }else
     {


### PR DESCRIPTION
When an entry node contains a precondition (or the "only once" flag), it is currently executed regardless of that precondition.
This check should avoid this.