### PR TITLE
fixing stopping audio when no audio is currently played

### DIFF
--- a/src/audio_manager.cpp
+++ b/src/audio_manager.cpp
@@ -12,6 +12,11 @@ AudioManager::AudioManager() = default;
 
 void AudioManager::stopMusic()
 {
+    if(currentMusic.empty())
+    {
+        return;
+    }
+
     Channels::handle().music.stop(currentMusic);
     currentMusic = "";
 }


### PR DESCRIPTION
stopMusic used to crash when no music was currently playing